### PR TITLE
Add snappy compressor to MongoDB config

### DIFF
--- a/.s2i/configs/datasources.production.js
+++ b/.s2i/configs/datasources.production.js
@@ -5,6 +5,7 @@ module.exports = {
     port: process.env.DB_PORT || 27017,
     user: process.env.MONGODB_USER,
     password: process.env.MONGODB_PASSWORD,
-    database: process.env.MONGODB_DATABASE || 'notify-bc'
-  }
-}
+    database: process.env.MONGODB_DATABASE || 'notify-bc',
+    compressors: ['snappy'],
+  },
+};


### PR DESCRIPTION
Configured the production datasource to use the 'snappy' compressor for MongoDB connections.  Used to prevent CVE-2025-14847 until we can do a proper database update.